### PR TITLE
Add an error message when the request to retrieve a Nugget fails

### DIFF
--- a/classes/naas_client.php
+++ b/classes/naas_client.php
@@ -47,26 +47,6 @@ class naas_client {
     }
 
     /**
-     * Log
-     * @param string $message
-     * @return void
-     */
-    private function log($message) {
-        debugging("[NaaS] {$message}", DEBUG_DEVELOPER);
-    }
-
-    /**
-     * Log when debug mode is activated
-     * @param string $message
-     * @return void
-     */
-    private function debug($message) {
-        if ($this->debug) {
-            $this->log($message);
-        }
-    }
-
-    /**
      * Makes an HTTP request returns the json decoded body or null in case of http error.
      * @param string $protocol
      * @param string $service
@@ -114,16 +94,14 @@ class naas_client {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $body = curl_exec($ch);
         $code = curl_getinfo ( $ch, CURLINFO_RESPONSE_CODE );
-        $contenttype = curl_getinfo ($ch, CURLINFO_CONTENT_TYPE );
-        if (curl_errno($ch)) {
-            echo 'Curl error: ' . curl_error($ch);
+        if (curl_errno($ch) && $this->debug) {
+            $message = 'Curl error: ' . curl_error($ch);
+            debugging($message, DEBUG_DEVELOPER);
         }
-        if ($code != 200) {
-            $this->log("Request failed: ".$protocol." - ".$url." (".$code.")");
-            if (curl_errno($ch)) {
-                $this->log('=> Curl error: ' . curl_error($ch));
-            }
-            $this->debug($body);
+        if ($code != 200 && $this->debug) {
+            $message = "Request failed: ".$protocol." - ".$url." (".$code.")";
+            debugging($message, DEBUG_NORMAL);
+            debugging($body, DEBUG_DEVELOPER);
         }
         curl_close($ch);
 
@@ -151,15 +129,25 @@ class naas_client {
     private function handle_result($res) {
         if ($res != null) {
             if (property_exists($res, "payload") && ($res->payload != null || is_array($res->payload))) {
-                $this->debug("Payload: ".json_encode($res->payload, JSON_PRETTY_PRINT));
+                if($this->debug) {
+                    debugging("Payload: ".json_encode($res->payload, JSON_PRETTY_PRINT), DEBUG_DEVELOPER);
+                }
+
                 return $res->payload;
             } else if (property_exists($res, "error")) {
-                $this->debug(json_encode($res->error, JSON_PRETTY_PRINT));
+                if($this->debug) {
+                    debugging("An error occurred on the NaaS server", DEBUG_NORMAL);
+                    debugging(json_encode($res->error, JSON_PRETTY_PRINT), DEBUG_DEVELOPER);
+                }
             } else {
-                $this->debug("Unexpected_error");
+                if($this->debug) {
+                    debugging("Unexpected error occurred on the NaaS server", DEBUG_NORMAL);
+                }
             }
         } else {
-            $this->debug("Unexpected_error");
+            if($this->debug) {
+                debugging("Unexpected error occurred on the NaaS server", DEBUG_NORMAL);
+            }
         }
         return $res;
     }
@@ -169,7 +157,6 @@ class naas_client {
      * @return array|mixed
      */
     public function get_api_info() {
-        $this->debug("Get API info");
         $protocol = "GET";
         $config = $this->request($protocol, "");
         return $this->handle_result($config);
@@ -185,7 +172,6 @@ class naas_client {
         if ($structureid == null) {
             $structureid = $this->config->naas_structure_id;
         }
-        $this->debug("Get nugget LTI config: ".$nuggetid);
         $protocol = "GET";
         $params = [ "structure_id" => $structureid ];
         $service = "/nuggets/".$nuggetid."/lti";
@@ -199,7 +185,6 @@ class naas_client {
      * @return array|mixed
      */
     public function get_nugget_data($nuggetid) {
-        $this->debug("Get nugget data: ".$nuggetid);
         $protocol = "GET";
         $params = [ "nugget_id" => $nuggetid ];
         $service = "/nuggets/".$nuggetid."/default_version";
@@ -212,7 +197,6 @@ class naas_client {
      * @return array|mixed
      */
     public function get_connected_user() {
-        $this->debug("Getting user information");
         $protocol = "GET";
         $service = "/auth";
         $result = $this->request($protocol, $service);
@@ -226,7 +210,6 @@ class naas_client {
      * @param object $data
      */
     public function post_xapi_statement($verb, $versionid, $data) {
-        $this->debug("Send xAPI statement to LRS");
         $protocol = "POST";
         $service = "/versions/{$versionid}/records/{$verb}";
 

--- a/classes/naas_client.php
+++ b/classes/naas_client.php
@@ -129,23 +129,23 @@ class naas_client {
     private function handle_result($res) {
         if ($res != null) {
             if (property_exists($res, "payload") && ($res->payload != null || is_array($res->payload))) {
-                if($this->debug) {
+                if ($this->debug) {
                     debugging("Payload: ".json_encode($res->payload, JSON_PRETTY_PRINT), DEBUG_DEVELOPER);
                 }
 
                 return $res->payload;
             } else if (property_exists($res, "error")) {
-                if($this->debug) {
+                if ($this->debug) {
                     debugging("An error occurred on the NaaS server", DEBUG_NORMAL);
                     debugging(json_encode($res->error, JSON_PRETTY_PRINT), DEBUG_DEVELOPER);
                 }
             } else {
-                if($this->debug) {
+                if ($this->debug) {
                     debugging("Unexpected error occurred on the NaaS server", DEBUG_NORMAL);
                 }
             }
         } else {
-            if($this->debug) {
+            if ($this->debug) {
                 debugging("Unexpected error occurred on the NaaS server", DEBUG_NORMAL);
             }
         }

--- a/classes/naas_lti.php
+++ b/classes/naas_lti.php
@@ -31,19 +31,13 @@ namespace mod_naas;
 class naas_lti {
 
     /**
-     * Default constructor
-     */
-    public function __construct() {
-    }
-
-    /**
      * Launch LTI content.
      * @param int $naasinstanceid
      * @param string $language
      * @return void
      * @throws \Random\RandomException
      */
-    public function lti_launch($naasinstanceid, $language="") {
+    public static function lti_launch($naasinstanceid, $language="") {
         global $PAGE;
         global $DB;
         global $CFG;
@@ -75,8 +69,29 @@ class naas_lti {
         }
 
         if ($nuggetconfig == null || isset($nuggetconfig->error)) {
-            debugging(" Cannot get nugget information from NaaS server. ");
-            echo(" Cannot get nugget information from NaaS server. ");
+            $errormessage = get_string("naas_unable_connect", "naas");
+            echo <<<HTML
+<style>
+.error-message {
+  color: #721c24;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  padding: 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: bold;
+  margin: 10px 0;
+  display: flex;
+  align-items: center;
+}
+
+.error-message::before {
+  content: "⚠️";
+  margin-right: 8px;
+}
+</style>
+    <div class="error-message">$errormessage</div>
+HTML;
             return;
         }
 

--- a/lang/en/naas.php
+++ b/lang/en/naas.php
@@ -70,7 +70,7 @@ $string['lastmodified'] = 'Last modified';
 $string['moduleintro'] = 'Introduction to the module';
 $string['name_display'] = 'Name to display';
 $string['name_help'] = 'Name of the nugget that will appear in the course section';
-$string['naas_unable_connect'] = 'Unable to contact the NaaS server';
+$string['naas_unable_connect'] = 'Unable to contact the NaaS server.';
 $string['unlimited'] = 'Unlimited';
 
 // Vue Form.

--- a/launch.php
+++ b/launch.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Moodle Nugget Plugin : launch LTI
+ * Load a Nugget using LTI
  *
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @copyright (C) 2019  ISAE-SUPAERO (https://www.isae-supaero.fr/)
@@ -35,6 +35,5 @@ $course = $DB->get_record('course', ['id' => $cm->course], '*', MUST_EXIST);
 require_login($course, true, $cm);
 require_capability('mod/naas:view', $context);
 
-// Launch LTI.
-$naasmoodle = new \mod_naas\naas_lti();
-$naasmoodle->lti_launch($id, $language);
+\mod_naas\naas_lti::lti_launch($id, $language);
+


### PR DESCRIPTION
- Improve debugging in `naas_client.php`
- Add an error message when the LTI connector fails to retrive the nugget

Note : I wasn't of the CSS requirements in the iframe so I've just inlined the style to display the error in case the Nugget is not loaded. It guarantees no side-effect when loading the Nugget.

### Screenshot
![image](https://github.com/user-attachments/assets/78b63bfd-3612-4f6c-a019-e548b08a7aec)

### How to test
Set up an invalid NaaS API URL and try to play a Nugget.
