### PR TITLE
fix: Allow to access person, domain, and structure with "mod/naas:view" capability

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -57,21 +57,21 @@ switch ($action) {
 
     case 'get-domain':
         $courseid = required_param('courseId',  PARAM_INT);
-        require_capability('mod/naas:addinstance', context_course::instance($courseid));
+        require_capability('mod/naas:view', context_course::instance($courseid));
         $domainkey = required_param('domainKey',  PARAM_TEXT);
         $url = "/vocabularies/nugget_domains_vocabulary/{$domainkey}";
         break;
 
     case 'get-structure':
         $courseid = required_param('courseId',  PARAM_INT);
-        require_capability('mod/naas:addinstance', context_course::instance($courseid));
+        require_capability('mod/naas:view', context_course::instance($courseid));
         $structurekey = required_param('structureKey',  PARAM_TEXT);
         $url = "/structures/{$structurekey}";
         break;
 
     case 'get-person':
         $courseid = required_param('courseId',  PARAM_INT);
-        require_capability('mod/naas:addinstance', context_course::instance($courseid));
+        require_capability('mod/naas:view', context_course::instance($courseid));
         $personkey = required_param('personKey',  PARAM_TEXT);
         $url = "/persons/{$personkey}";
         break;


### PR DESCRIPTION
When a learner view a nugget, it also retrieves bound persons, structures and domains.

I had restricted person, domain & structure to `mod/naas:addinstance` capability, and so learners could not access anymore the Nugget.

With this change, it is now required to have the `mod/naas:view` capability.