### PR TITLE
Fix: Generate new sourced_id for each LTI retry attempt

### DIFF
--- a/classes/naas_lti.php
+++ b/classes/naas_lti.php
@@ -107,6 +107,14 @@ HTML;
         // To store in database: user id, activity id, secret.
         $userid = $USER->id;
         $activityid = $cm->id;
+        
+        // Clean up any existing sourced_id records for this user-activity combination
+        // to ensure each new attempt gets a fresh sourced_id
+        $DB->delete_records('naas_activity_outcome', [
+            'user_id' => $userid,
+            'activity_id' => $activityid
+        ]);
+        
         $sourcedid = bin2hex(random_bytes(16)); // 16 bytes to obtain a 32-character hexadecimal string.
 
         // Insert a record in the database.

--- a/outcome.php
+++ b/outcome.php
@@ -42,8 +42,27 @@ if ($records) {
         $userid = $record->user_id;
         $activityid = $record->activity_id;
     }
+} else {
+    // Send error response as per LTI spec
+    echo '<?xml version="1.0" encoding="UTF-8"?>
+<imsx_POXEnvelopeResponse xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+    <imsx_POXHeader>
+        <imsx_POXResponseHeaderInfo>
+            <imsx_version>V1.0</imsx_version>
+            <imsx_messageIdentifier>999999123</imsx_messageIdentifier>
+            <imsx_statusInfo>
+                <imsx_codeMajor>failure</imsx_codeMajor>
+                <imsx_severity>status</imsx_severity>
+                <imsx_description>No matching sourced_id found</imsx_description>
+            </imsx_statusInfo>
+        </imsx_POXResponseHeaderInfo>
+    </imsx_POXHeader>
+    <imsx_POXBody>
+        <replaceResultResponse/>
+    </imsx_POXBody>
+</imsx_POXEnvelopeResponse>';
+    exit;
 }
-
 
 // Course data.
 $cm = get_coursemodule_from_id('naas', $activityid, 0, false, MUST_EXIST);
@@ -107,4 +126,22 @@ if (!$completion->is_enabled()) {
 
 $targetstate = COMPLETION_COMPLETE;
 $completion->update_state($cm, $targetstate);
-debugging("completion_complete", DEBUG_DEVELOPER);
+
+// Send success response as per LTI spec
+echo '<?xml version="1.0" encoding="UTF-8"?>
+<imsx_POXEnvelopeResponse xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+    <imsx_POXHeader>
+        <imsx_POXResponseHeaderInfo>
+            <imsx_version>V1.0</imsx_version>
+            <imsx_messageIdentifier>999999123</imsx_messageIdentifier>
+            <imsx_statusInfo>
+                <imsx_codeMajor>success</imsx_codeMajor>
+                <imsx_severity>status</imsx_severity>
+                <imsx_description>Grade successfully processed</imsx_description>
+            </imsx_statusInfo>
+        </imsx_POXResponseHeaderInfo>
+    </imsx_POXHeader>
+    <imsx_POXBody>
+        <replaceResultResponse/>
+    </imsx_POXBody>
+</imsx_POXEnvelopeResponse>';


### PR DESCRIPTION
We also needed to include the xml output to respect LTI rules.