### PR TITLE
fix: naas_grade_item_update which breaks hide / show section function…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -413,7 +413,11 @@ function naas_grade_item_update($nugget, $grades = null) {
     }
 
     $params['gradetype'] = GRADE_TYPE_VALUE;
-    $params['grademax'] = $nugget->maxgrade;
+
+    if(isset($nugget->maxgrade)) {
+        $params['grademax'] = $nugget->maxgrade;
+    }
+    
     $params['grademin'] = 0;
 
     return grade_update('mod/naas', $nugget->course, 'mod', 'naas', $nugget->id, 0, $grades, $params);

--- a/lib.php
+++ b/lib.php
@@ -414,10 +414,9 @@ function naas_grade_item_update($nugget, $grades = null) {
 
     $params['gradetype'] = GRADE_TYPE_VALUE;
 
-    if(isset($nugget->maxgrade)) {
+    if (isset($nugget->maxgrade)) {
         $params['grademax'] = $nugget->maxgrade;
     }
-    
     $params['grademin'] = 0;
 
     return grade_update('mod/naas', $nugget->course, 'mod', 'naas', $nugget->id, 0, $grades, $params);


### PR DESCRIPTION
The `naas_grade_item_update function was always update the max grade which is incorrect.

When no max grade provided (i.e. update not coming from the activity form) it was failing on trying to set max grade as null.

This bug was breaking the hide / show section functionality.