### PR TITLE
feat: send launch_presentation_locale so naas_api can resolve ui_lang…

### DIFF
--- a/classes/naas_lti.php
+++ b/classes/naas_lti.php
@@ -153,6 +153,8 @@ HTML;
             "lis_result_sourcedid" => $sourcedid,
             "lis_outcome_service_url" => $CFG->wwwroot . "/mod/naas/outcome.php?id=" . $cm->id,
             "resource_link_id" => $resourcelinkid,
+            // Learner interface language, so naas_api can resolve ui_language.
+            "launch_presentation_locale" => current_language(),
             "custom_naas" => json_encode($custom),
         ];
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version        = 2026030900;                  // The current module version (Date: YYYYMMDDXX).
-$plugin->release        = "2.5.1";
+$plugin->version        = 2026080300;                  // The current module version (Date: YYYYMMDDXX).
+$plugin->release        = "2.5.2";
 $plugin->requires       = 2022041900;                  // Requires this Moodle version.
 $plugin->component      = 'mod_naas';                  // Full name of the plugin (used for diagnostics).
 $plugin->cron           = 0;                           // Frequency of the plugin's cron task.


### PR DESCRIPTION
Ajoute la langue d'interface de l'apprenant Moodle au lancement LTI du nugget, afin que naas_api puisse résoudre la langue de l'interface (ui_language) du cadre du nugget (crédits, CGU, libellés, valeurs de métadonnées).

Changements :

classes/naas_lti.php : ajoute "launch_presentation_locale" => current_language() aux $launchdata avant la signature (donc inclus dans le base string signé — paramètre LTI standard).
version.php : bump version (2026080300) + release (2.5.2) pour déclencher la mise à jour du plugin côté Moodle.
Sûreté / rétro-compat :

Additif et correctement signé → aucun impact sur les lancements existants.
Compatible dans les deux sens (ancien plugin ↔ nouvelle API, et inversement) : une combinaison mixte n'active simplement pas encore la fonctionnalité (repli sur la langue du nugget), sans jamais d'erreur.
⚠️ Effet visible seulement une fois naas_api (résolution ui_language) déployé.